### PR TITLE
Hiding the Demo-site Try-out option from the Home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,8 @@ sm-decription: text
                      <p>This sandbox provides a simulated environment to test the waters of WSO2 Open Banking. It allows users
                         to subscribe and consume APIs from the context of a banking application.
                      </p>
-                     <a href="https://sandbox-openbanking.wso2.com/store/apis/list" class="cButton cDownloadButton">Try it out</a>
+                     <a href="https://sandbox-openbanking.wso2.com/store/apis/list" class="cButton cDownloadButton"
+                        style="display: none">Try it out</a>
                      <a href="/sandbox-guide-uk" class="cButton cDownloadButton">View guide</a>
                   </div>
                   <div class="cSliderImage col-sm-12 col-md-6 col-lg-6">

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@ sm-decription: text
                      </p>
                      <a href="https://sandbox-openbanking.wso2.com/store/apis/list" class="cButton cDownloadButton"
                         style="display: none">Try it out</a>
-                     <a href="/sandbox-guide-uk" class="cButton cDownloadButton">View guide</a>
+                     <a href="/sandbox-guide-uk" class="cButton cDownloadButton" style="display: none">View guide</a>
                   </div>
                   <div class="cSliderImage col-sm-12 col-md-6 col-lg-6">
                      <img src="/img/demo-pc.png"/>


### PR DESCRIPTION
## Purpose
To hide the option to Try-out the OB Demo-site until completely hosting it.