### PR TITLE
Removed demo-site references from documentation

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -15,8 +15,8 @@
           </button>
           <div id="navbarNavDropdown" class="navbar-collapse collapse">
               <ul class="navbar-nav me-auto">
-        
-  
+
+
               </ul>
               <!-- <ul class="navbar-nav">
                   <li class="nav-item dropdown">
@@ -45,7 +45,7 @@
                     <li class="nav-item ">
                       <a class="nav-link" href="/accelerator">Accelerator</a>
                     </li>
-            
+
                     <li class="nav-item dropdown ">
                       <a class="nav-link dropdown-toggle" href="javascript:void(0)" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Use Case Demos </a>
                       <div class="dropdown-menu dropdown-menu-right" aria-labelledby="demos">
@@ -60,20 +60,20 @@
                         <a class="dropdown-item " href="https://wso2.com/blog/industry-solutions">Blogs</a>
                       </div>
                     </li>
-                    <li class="nav-item dropdown">
-                      <a class="nav-link dropdown-toggle" href="javascript:void(0)" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Developer Portal</a>
-                      <div class="dropdown-menu dropdown-menu-right" aria-labelledby="psd2">
-                        <a class="dropdown-item " href="/sandbox-guide">Sandbox Guide </a>
-                        <a class="dropdown-item" href="https://sandbox-openbanking.wso2.com" target="_blank">
-                            Sandbox</a>
-                      </div>
-                    </li>
+<!--                    <li class="nav-item dropdown">-->
+<!--                      <a class="nav-link dropdown-toggle" href="javascript:void(0)" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Developer Portal</a>-->
+<!--                      <div class="dropdown-menu dropdown-menu-right" aria-labelledby="psd2">-->
+<!--                        <a class="dropdown-item " href="/sandbox-guide">Sandbox Guide </a>-->
+<!--                        <a class="dropdown-item" href="https://sandbox-openbanking.wso2.com" target="_blank">-->
+<!--                            Sandbox</a>-->
+<!--                      </div>-->
+<!--                    </li>-->
                     <li class="nav-item ">
                       <a class="nav-link" terget="_blank" href="https://wso2.com/contact/?src=open-banking">Contact <span class="visually-hidden">(current)</span></a>
                     </li>
             </ul>
 
-                  
+
           </div>
       </nav>
 
@@ -98,4 +98,4 @@
 
 
 
- 
+

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -69,7 +69,7 @@
 <!--                      </div>-->
 <!--                    </li>-->
                     <li class="nav-item ">
-                      <a class="nav-link" terget="_blank" href="https://wso2.com/contact/?src=open-banking">Contact <span class="visually-hidden">(current)</span></a>
+                      <a class="nav-link" target="_blank" href="https://wso2.com/contact/?src=open-banking">Contact <span class="visually-hidden">(current)</span></a>
                     </li>
             </ul>
 

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ sm-decription: text
                      <p>This sandbox provides a simulated environment to test the waters of WSO2 Open Banking. It allows users
                         to subscribe and consume APIs from the context of a banking application.
                      </p>
-                     <a href="/sandbox-guide" class="cButton cDownloadButton">Try it out</a>
+                     <a href="https://wso2.com/contact/?src=open-banking" class="cButton cDownloadButton">Try it out</a>
                   </div>
                   <div class="cSliderImage col-sm-12 col-md-6 col-lg-6">
                      <img src="/img/demo-pc.png"/>
@@ -49,10 +49,10 @@ sm-decription: text
                   <div class="row">
                   <div class="cSliderContent col-sm-12 col-md-6 col-lg-6">
                      <h2>Account Aggregation Customer Journey</h2>
-                     <p>Understanding the customer's journey through Open Banking account aggregation. 
+                     <p>Understanding the customer's journey through Open Banking account aggregation.
                      </p>
                      <a href="https://openbanking.wso2.com/demos/aisp" class="cButton cDownloadButton">View Demo</a>
-                  
+
                   </div>
                   <div class="cSliderImage col-sm-12 col-md-6 col-lg-6">
                      <img src="/img/demo-tab.png"/>
@@ -169,12 +169,12 @@ sm-decription: text
   <div class="container">
     <div class="row cHighlightedRow">
       <div class="col-sm-12 col-md-12">
-        
-             
 
-         
 
-        
+
+
+
+
         <div class="cHighlighted cWhiteBG">
             <div class="row">
               <!-- <div class="col-sm-12 col-md-12 col-lg-12">
@@ -185,15 +185,15 @@ sm-decription: text
                  </h5>
                 <p>Find out more about WSO2 Open Banking, a platform that helps financial institutions comply with open banking regulations and offer tools for new financial products and services.</p>
                 <a href="https://wso2.com/solutions/financial/open-banking/?a=estimate" class="cButton cDownloadButton">Read more</a>
-           
+
               </div>
-              <div class="col-sm-12 col-md-4 col-lg-4">  
-               
-  
+              <div class="col-sm-12 col-md-4 col-lg-4">
+
+
               </div>
-  
+
             </div>
-  
+
           </div>
 
 
@@ -201,6 +201,6 @@ sm-decription: text
       </div>
     </div>
 
-    
+
   </div>
 </section>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ sm-decription: text
                      <p>This sandbox provides a simulated environment to test the waters of WSO2 Open Banking. It allows users
                         to subscribe and consume APIs from the context of a banking application.
                      </p>
-                     <a href="https://wso2.com/contact/?src=open-banking" class="cButton cDownloadButton">Try it out</a>
+                     <a href="https://wso2.com/contact/?src=open-banking" class="cButton cDownloadButton">Contact Us</a>
                   </div>
                   <div class="cSliderImage col-sm-12 col-md-6 col-lg-6">
                      <img src="/img/demo-pc.png"/>

--- a/sandbox-guide.md
+++ b/sandbox-guide.md
@@ -1,9 +1,10 @@
----
-layout: ob-base-toc-page
-title: Quick Start Guide 
-intro: Try out the Open Banking APIs in the Developer Portal
-toc: true
----
+[//]: # (---)
+[//]: # (layout: ob-base-toc-page)
+[//]: # (title: Quick Start Guide )
+[//]: # (intro: Try out the Open Banking APIs in the Developer Portal)
+[//]: # (toc: true)
+[//]: # (---)
+[//]: # (Uncomment above to enable this page.)
 
 This guide walks you through the WSO2 Open Banking Accelerator Sandbox.
 


### PR DESCRIPTION
## Purpose

Removed references to the demo site from the documentation to prevent confusion.
This was decision was taken during below meeting.

```
Discuss plan for demo site
Monday, November 10 · 10:30 – 11:00am
```

## Goals
- Clean up references to the demo site.
- Maintain consistency and accuracy across all product documentation.

## Approach
- Searched the documentation for “demo-site” references.
- Removed or replaced them with the appropriate `contact-us` page.


## Release note
Removed demo-site references from documentation for improved clarity and consistency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Navigation Updates**
  * Removed Developer Portal entry from the site navigation
  * Updated Sandbox "Try it out" link to point to external contact page

* **Bug Fixes**
  * Corrected contact link target attribute

* **Documentation**
  * Disabled the Sandbox guide page (marked inactive)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->